### PR TITLE
work with collection.anki21 apkgs

### DIFF
--- a/apkg.js
+++ b/apkg.js
@@ -125,8 +125,10 @@ function ankiBinaryToTable(ankiArray, options) {
     var compressed = new Uint8Array(ankiArray);
     var unzip = new Zlib.Unzip(compressed);
     var filenames = unzip.getFilenames();
-    if (filenames.indexOf("collection.anki2") >= 0) {
-        var plain = unzip.decompress("collection.anki2");
+    var anki21Exists = filenames.indexOf("collection.anki21") >= 0;
+    var sqliteFile = anki21Exists ? "collection.anki21" : "collection.anki2";
+    if (filenames.indexOf(sqliteFile) >= 0) {
+        var plain = unzip.decompress(sqliteFile);
         sqlToTable(plain);
         if (options && options.loadImage){
           if (filenames.indexOf("media") >= 0) {


### PR DESCRIPTION
Fixes #21. New Anki apkg files contain both `collection.anki2` and `collection.anki21` SQLite databases. I'm not sure what the difference is but all the things we expected in the old one is in this new database (same tables and columns).

So this PR will just check if the new database is available and if so open that, otherwise it'll try to open the old one.

Tested with the example apkg from #21 (new file) as well as an old apkg I had lying around, both work.